### PR TITLE
Add feature of specifically vaccinating, healing and infecting an individual agent

### DIFF
--- a/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseAgentParams.java
+++ b/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseAgentParams.java
@@ -79,7 +79,7 @@ public class DiseaseAgentParams implements ResizableParam {
 	/**
 	 * Agent types this agent type can transmit the disease to.
 	 */
-	@ConfDisplayName("Transmit to")
+	@ConfDisplayName("Transmit to Agent")
 	@ConfXMLTag("transmitTo")
 	@ConfList(indexName = "Agent", startAtOne = true)
 	public boolean[] transmitTo = new boolean[0];
@@ -87,7 +87,7 @@ public class DiseaseAgentParams implements ResizableParam {
 	/**
 	 * Agent types this agent type can heal.
 	 */
-	@ConfDisplayName("Heal")
+	@ConfDisplayName("Heal Agent")
 	@ConfXMLTag("heal")
 	@ConfList(indexName = "Agent", startAtOne = true)
 	public boolean[] canHeal = new boolean[0];
@@ -95,7 +95,7 @@ public class DiseaseAgentParams implements ResizableParam {
 	/**
 	 * Agent types this agent type can vaccinate.
 	 */
-	@ConfDisplayName("Vaccinate")
+	@ConfDisplayName("Vaccinate Agent")
 	@ConfXMLTag("vaccinate")
 	@ConfList(indexName = "Agent", startAtOne = true)
 	public boolean[] canVaccinate = new boolean[0];

--- a/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseAgentParams.java
+++ b/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseAgentParams.java
@@ -77,12 +77,28 @@ public class DiseaseAgentParams implements ResizableParam {
 	public int recoveryTime = 0;
 
 	/**
-	 * Agent types this agent can transmit the disease to.
+	 * Agent types this agent type can transmit the disease to.
 	 */
 	@ConfDisplayName("Transmit to")
 	@ConfXMLTag("transmitTo")
 	@ConfList(indexName = "Agent", startAtOne = true)
 	public boolean[] transmitTo = new boolean[0];
+
+	/**
+	 * Agent types this agent type can heal.
+	 */
+	@ConfDisplayName("Heal")
+	@ConfXMLTag("heal")
+	@ConfList(indexName = "Agent", startAtOne = true)
+	public boolean[] canHeal = new boolean[0];
+
+	/**
+	 * Agent types this agent type can vaccinate.
+	 */
+	@ConfDisplayName("Vaccinate")
+	@ConfXMLTag("vaccinate")
+	@ConfList(indexName = "Agent", startAtOne = true)
+	public boolean[] canVaccinate = new boolean[0];
 
 	@Deprecated // for reflection use only!
 	public DiseaseAgentParams(){
@@ -96,6 +112,10 @@ public class DiseaseAgentParams implements ResizableParam {
 	public void resize(AgentFoodCountable size) {
 		boolean[] n = Arrays.copyOf(transmitTo, size.getAgentTypes());
 		this.transmitTo = n;
+		boolean[] m = Arrays.copyOf(canHeal, size.getAgentTypes());
+		this.canHeal = m;
+		boolean[] o = Arrays.copyOf(canVaccinate, size.getAgentTypes());
+		this.canVaccinate = o;
 	}
 
 	private static final long serialVersionUID = 2L;

--- a/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseAgentParams.java
+++ b/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseAgentParams.java
@@ -21,6 +21,13 @@ public class DiseaseAgentParams implements ResizableParam {
 	public float initialInfection = 0;
 
 	/**
+	 * Fraction of initially vaccinated agents.
+	 */
+	@ConfXMLTag("initialVaccination")
+	@ConfDisplayName("Initially vaccinated fraction")
+	public float initialVaccination = 0;
+
+	/**
 	 * Chance this agent will get a disease from contact with an infected agent.
 	 */
 	@ConfXMLTag("contactTransmitRate")

--- a/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseMutator.java
+++ b/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseMutator.java
@@ -158,13 +158,16 @@ public class DiseaseMutator extends StatefulMutatorBase<DiseaseState> implements
 		int tr = bumper.getType();
 		int te = bumpee.getType();
 
-		if (params.agentParams[tr].vaccinator && !isSick(bumpee) ) {
+		if (params.agentParams[tr].vaccinator && !isSick(bumpee) && params.agentParams[tr].canVaccinate[te]) {
+			// the effectiveness is determined by the vaccinator agent type
+			// TODO: Maybe we can determine the effectiveness by the vaccinated agent types
 			vaccinate(bumpee, params.agentParams[tr].vaccineEffectiveness);
 		}
 
-		if (params.agentParams[tr].healer && isSick(bumpee)) {
+		// Modify the logics here to not remove vaccination after being healed
+		if (params.agentParams[tr].healer && isSick(bumpee) && params.agentParams[tr].canHeal[te]) {
 			if (simulation.getRandom().nextFloat() < params.agentParams[tr].healerEffectiveness) {
-				unSick(bumpee);
+				heal(bumpee);
 			}
 		}
 
@@ -196,19 +199,21 @@ public class DiseaseMutator extends StatefulMutatorBase<DiseaseState> implements
 		return hasAgentState(agent) && getAgentState(agent).vaccinated;
 	}
 
+	// This method is for vaccinators to vaccinate agents
 	public void vaccinate(Agent bumpee, float effectiveness) {
 		DiseaseAgentParams agentParams = params.agentParams[bumpee.getType()];
 		setAgentState(bumpee, new DiseaseState(agentParams, false, true, effectiveness));
 	}
 
-	public void vaccinate(Agent bumpee) {
-		DiseaseAgentParams agentParams = params.agentParams[bumpee.getType()];
-		setAgentState(bumpee, new DiseaseState(agentParams, false, true, agentParams.vaccineEffectiveness));
+	// This method is for users to specifically vaccinate an individual agent
+	public void vaccinate(Agent agent) {
+		DiseaseAgentParams agentParams = params.agentParams[agent.getType()];
+		setAgentState(agent, new DiseaseState(agentParams, false, true, agentParams.vaccineEffectiveness));
 	}
 
-	public void deVaccinate(Agent bumpee) {
-		DiseaseAgentParams agentParams = params.agentParams[bumpee.getType()];
-		setAgentState(bumpee, new DiseaseState(agentParams, false, false, 0.0f));
+	public void deVaccinate(Agent agent) {
+		DiseaseAgentParams agentParams = params.agentParams[agent.getType()];
+		setAgentState(agent, new DiseaseState(agentParams, false, false, 0.0f));
 	}
 
 	public void heal(Agent agent) {

--- a/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseMutator.java
+++ b/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseMutator.java
@@ -79,6 +79,18 @@ public class DiseaseMutator extends StatefulMutatorBase<DiseaseState> implements
 
 	}
 
+	private void makeRandomVaccinated(Agent agent, float rate) {
+		boolean isVaccinated = false;
+		if (simulation.getRandom().nextFloat() < rate) {
+			isVaccinated = true;
+		}
+		if (isVaccinated) {
+			DiseaseAgentParams agentParams = params.agentParams[agent.getType()];
+			setAgentState(agent, new DiseaseState(agentParams, false, true, agentParams.vaccineEffectiveness));
+		}
+	}
+
+
 	public void contactTransmit(Agent agent, float rate) {
 		boolean isSick = false;
 		if (simulation.getRandom().nextFloat() < rate)
@@ -114,7 +126,10 @@ public class DiseaseMutator extends StatefulMutatorBase<DiseaseState> implements
 
 	@Override
 	public void onSpawn(Agent agent) {
-		makeRandomSick(agent, params.agentParams[agent.getType()].initialInfection);
+		makeRandomVaccinated(agent, params.agentParams[agent.getType()].initialVaccination);
+		if (!isVaccinated(agent)) {
+			makeRandomSick(agent, params.agentParams[agent.getType()].initialInfection);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseMutator.java
+++ b/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseMutator.java
@@ -79,7 +79,7 @@ public class DiseaseMutator extends StatefulMutatorBase<DiseaseState> implements
 
 	}
 
-	private void contactTransmit(Agent agent, float rate) {
+	public void contactTransmit(Agent agent, float rate) {
 		boolean isSick = false;
 		if (simulation.getRandom().nextFloat() < rate)
 			isSick = true;
@@ -168,7 +168,7 @@ public class DiseaseMutator extends StatefulMutatorBase<DiseaseState> implements
 		}
 	}
 
-	private void unSick(Agent agent) {
+	public void unSick(Agent agent) {
 		removeAgentState(agent);
 		sickCount[agent.getType()]--;
 	}
@@ -186,9 +186,24 @@ public class DiseaseMutator extends StatefulMutatorBase<DiseaseState> implements
 		setAgentState(bumpee, new DiseaseState(agentParams, false, true, effectiveness));
 	}
 
+	public void vaccinate(Agent bumpee) {
+		DiseaseAgentParams agentParams = params.agentParams[bumpee.getType()];
+		setAgentState(bumpee, new DiseaseState(agentParams, false, true, agentParams.vaccineEffectiveness));
+	}
+
 	public void deVaccinate(Agent bumpee) {
 		DiseaseAgentParams agentParams = params.agentParams[bumpee.getType()];
 		setAgentState(bumpee, new DiseaseState(agentParams, false, false, 0.0f));
+	}
+
+	public void heal(Agent agent) {
+		if (isVaccinated(agent)) {
+			DiseaseAgentParams agentParams = params.agentParams[agent.getType()];
+			setAgentState(agent, new DiseaseState(agentParams, false, true, agentParams.vaccineEffectiveness));
+			sickCount[agent.getType()]--;
+		} else {
+			unSick(agent);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseState.java
+++ b/src/main/java/org/cobweb/cobweb2/plugins/disease/DiseaseState.java
@@ -39,6 +39,7 @@ public class DiseaseState implements AgentState {
 		this.vaccineEffectiveness = vaccineEffectiveness;
 	}
 
+
 	@Override
 	public boolean isTransient() {
 		return false;

--- a/src/main/java/org/cobweb/cobweb2/ui/swing/CobwebApplication.java
+++ b/src/main/java/org/cobweb/cobweb2/ui/swing/CobwebApplication.java
@@ -70,6 +70,8 @@ public class CobwebApplication extends JFrame {
 
 	private SimulatorUI simulatorUI;
 
+	private JMenu diseaseMenu;
+
 	private JMenu foodMenu;
 
 	private JMenu agentMenu;
@@ -197,9 +199,11 @@ public class CobwebApplication extends JFrame {
 		// Sub-menus created dynamically in #makeAgentFoodSelectMenu()
 		agentMenu = new JMenu("Select Agents");
 		foodMenu = new JMenu("Select Food");
+		diseaseMenu = new JMenu("Disease");
 		editMenu.add(new JMenuItem(setObservationMode));
 		editMenu.add(new JMenuItem(setModeStones));
-		editMenu.add(new JMenuItem(setVaccinateMode));
+		//		editMenu.add(new JMenuItem(setVaccinateMode));
+		editMenu.add(diseaseMenu);
 		editMenu.add(agentMenu);
 		editMenu.add(foodMenu);
 		editMenu.add(new JSeparator());
@@ -520,6 +524,8 @@ public class CobwebApplication extends JFrame {
 
 		makeViewMenu();
 
+		makeDiseaseMenu();
+
 		if (simulatorUI != null)
 			simulatorUI.simulationChanged(continuation);
 
@@ -588,6 +594,59 @@ public class CobwebApplication extends JFrame {
 			viewMenu.add(box);
 		}
 	}
+
+
+	private void makeDiseaseMenu() {
+		JMenuItem diseaseSubmenu[] = new JMenuItem[3];
+		diseaseMenu.removeAll();
+		String diseaseSubmenuActions[] = {"Vaccinate", "Heal", "Infect"};
+		for (int i = 0; i < 3; i++) {
+			diseaseSubmenu[i] = new JMenuItem(diseaseSubmenuActions[i]);
+			diseaseSubmenu[i].setActionCommand(diseaseSubmenuActions[i]);
+			diseaseSubmenu[i].addActionListener(new DiseaseMouseActionListener(diseaseSubmenuActions[i]));
+			diseaseMenu.add(diseaseSubmenu[i]);
+		}
+
+	}
+
+	private class DiseaseMouseActionListener implements ActionListener {
+
+		private final String type;
+
+		public DiseaseMouseActionListener(String type) {
+			this.type = type;
+
+		}
+
+		@Override
+		public void actionPerformed(ActionEvent e) {
+			simulatorUI.displayPanel.setMouseMode(MouseMode.ControlDisease, type);
+		}
+	}
+
+	//	private Action setVaccinateMode = new AbstractAction("Vaccinate") {
+	//		@Override
+	//		public void actionPerformed(ActionEvent e) {
+	//			simulatorUI.displayPanel.setMouseMode(MouseMode.Vaccinate);
+	//		}
+	//		private static final long serialVersionUID = 1L;
+	//	};
+	//
+	//	private Action setHealMode = new AbstractAction("Heal") {
+	//		@Override
+	//		public void actionPerformed(ActionEvent e) {
+	//			simulatorUI.displayPanel.setMouseMode(MouseMode.Heal);
+	//		}
+	//		private static final long serialVersionUID = 1L;
+	//	};
+	//
+	//	private Action setInfectionMode = new AbstractAction("Infect") {
+	//		@Override
+	//		public void actionPerformed(ActionEvent e) {
+	//			simulatorUI.displayPanel.setMouseMode(MouseMode.Infect);
+	//		}
+	//		private static final long serialVersionUID = 1L;
+	//	};
 
 	private void makeAgentFoodSelectMenu() {
 		JMenuItem foodtype[] = new JMenuItem[simRunner.getSimulation().getAgentTypeCount()];
@@ -931,13 +990,6 @@ public class CobwebApplication extends JFrame {
 		private static final long serialVersionUID = 1L;
 	};
 
-	private Action setVaccinateMode = new AbstractAction("Vaccinate") {
-		@Override
-		public void actionPerformed(ActionEvent e) {
-			simulatorUI.displayPanel.setMouseMode(MouseMode.GiveVaccine);
-		}
-		private static final long serialVersionUID = 1L;
-	};
 
 	private enum ReplaceMergeCancel {
 		CANCEL,

--- a/src/main/java/org/cobweb/cobweb2/ui/swing/MouseMode.java
+++ b/src/main/java/org/cobweb/cobweb2/ui/swing/MouseMode.java
@@ -1,5 +1,5 @@
 package org.cobweb.cobweb2.ui.swing;
 
 public enum MouseMode {
-	Observe, AddStone, AddFood, AddAgent, GiveVaccine
+	Observe, AddStone, AddFood, AddAgent, ControlDisease
 }


### PR DESCRIPTION
The newly-added feature enables users to specifically vaccinate, heal and infect an individual agent by clicking the individual agent in the same way as users add an agent or stone or food.
Also, the feature of deciding which agent a vaccinator or a healer can vaccinate or heal is on the way.